### PR TITLE
Feat/clean listen types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- add `listenAsync` for promised listen
+
+### Changed
+- **[BREAKING]** remove `listen` patch
 
 ## [0.3.0] - 2019-10-31
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Built on top of [express](https://github.com/expressjs/express/) and [this is al
 
 ## Features
 
-- Promised `listen`.
+- Promised `listenAsync`.
 - Destroyable server with `.destroy()`.
 - Error processing with serializable `HttpJsonError` and `errorHandler`
 - Includes
@@ -41,7 +41,7 @@ server.use(defaultRootHandler);
 server.use(errorHandler);
 server.use(defaultFinalHandler);
 
-server.listen(3000)
+server.listenAsync(3000)
     .then(() => console.log('Listening.'))
     .then(() => server.destroy())
     .then(() => console.log('Server shut down.'));

--- a/src/lib/util/override.ts
+++ b/src/lib/util/override.ts
@@ -1,4 +1,0 @@
-export default function override(subject: any, methodName: any, patch: any) {
-    const originalMethod = subject[methodName];
-    subject[methodName] = patch(originalMethod.bind(subject));
-}

--- a/src/test/server.test.ts
+++ b/src/test/server.test.ts
@@ -19,7 +19,7 @@ describe('Server', () => {
             const server = createServer();
             await new Promise((resolve, reject) =>
                 server
-                    .listen(3000)
+                    .listenAsync(3000)
                     .then(resolve)
                     .catch(reject)
             );
@@ -27,7 +27,7 @@ describe('Server', () => {
         });
         test('Destroyable server', async () => {
             const server = createServer();
-            await server.listen(3000);
+            await server.listenAsync(3000);
             server.destroy();
         });
     });


### PR DESCRIPTION
- introducing listenAsync

should fix most of the hassle about the interlieving types of express and unicore

Fixes #1 