### PR TITLE
Update deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: node_js
 node_js:
-- '8'
-- '9'
 - '10'
 - '12'
+- '13'
+- '14'
 
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter

--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
     "check": "npm-check -i app -i errors -i config -i index & exit 0"
   },
   "dependencies": {
-    "@google-cloud/storage": "^4.0.0",
-    "@types/cors": "^2.8.5",
-    "@types/multer": "^1.3.7",
+    "@google-cloud/storage": "^5.3.0",
+    "@types/cors": "^2.8.7",
+    "@types/multer": "^1.4.4",
     "@types/raven": "^2.5.3",
     "@types/server-destroy": "^1.0.0",
     "body-parser": "^1.18.3",
@@ -43,21 +43,21 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.6",
-    "@types/jest": "^24.0.21",
-    "@types/request-promise": "^4.1.43",
-    "@types/supertest": "^2.0.7",
-    "cross-env": "^6.0.3",
-    "husky": "^3.0.9",
-    "jest": "^24.5.0",
-    "lint-staged": "^9.4.2",
+    "@types/jest": "^26.0.14",
+    "@types/request-promise": "^4.1.46",
+    "@types/supertest": "^2.0.10",
+    "cross-env": "^7.0.2",
+    "husky": "^4.3.0",
+    "jest": "^26.4.2",
+    "lint-staged": "^10.4.0",
     "npm-check": "^5.9.2",
-    "prettier": "^1.15.3",
-    "prettier-config-ackee": "^0.0.13",
-    "request-promise": "^4.2.4",
-    "supertest": "^4.0.2",
-    "ts-jest": "^24.0.0",
+    "prettier": "^2.1.2",
+    "prettier-config-ackee": "0.0.14",
+    "request-promise": "^4.2.6",
+    "supertest": "^5.0.0",
+    "ts-jest": "^26.4.1",
     "tslint-config-ackee": "^0.3.0",
-    "typedoc": "^0.15.0",
-    "typescript": "^3.6.4"
+    "typedoc": "^0.19.2",
+    "typescript": "^4.0.3"
   }
 }

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -21,7 +21,7 @@ declare module 'express-serve-static-core' {
 }
 
 type PromisedListen = (...args: Parameters<core.Express['listen']>) => Promise<http.Server>;
-const patchListen = (app: core.Express) => (listen: core.Express['listen']): PromisedListen => {
+const patchListen = (app: core.Express) => (listen: any): PromisedListen => {
     app.destroy = () => Promise.reject(new Error('Server did not start yet'));
     return (...args) => {
         return new Promise((resolve, reject) => {


### PR DESCRIPTION
This PR fixes high valnurability in dependencies.
Bumps GCS SDK by major, which drops support for Node 8. Other breaking changes should not affect us AFAIK.

https://github.com/googleapis/nodejs-storage/releases/tag/v5.0.0