### PR TITLE
🐛Fix waiting for server to destroy

### DIFF
--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -3,6 +3,7 @@ import * as core from 'express-serve-static-core';
 import * as http from 'http';
 // @ts-ignore
 import * as destroyable from 'server-destroy';
+import { promisify } from 'util';
 import { bindExpress as bindSentry, SentrySettings } from './monitoring/sentry';
 
 export interface ServerOptions {
@@ -32,7 +33,7 @@ const patchListen = (app: core.Express) => (listen: any): PromisedListen => {
                 destroyable(server);
                 resolve(server);
             });
-            app.destroy = async () => server.destroy();
+            app.destroy = async () => await promisify(server.destroy)();
         });
     };
 };

--- a/src/test/server.test.ts
+++ b/src/test/server.test.ts
@@ -23,12 +23,12 @@ describe('Server', () => {
                     .then(resolve)
                     .catch(reject)
             );
-            server.destroy();
+            await server.destroy();
         });
         test('Destroyable server', async () => {
             const server = createServer();
             await server.listenAsync(3000);
-            server.destroy();
+            await server.destroy();
         });
     });
     describe('Body parsing', () => {


### PR DESCRIPTION
This pull request solves the situation when a client wants to wait for the server to destroy but actually, it does not. The problem was due to the fact, that the original `server.destroy()` is written in callback style and not in a promise based way.